### PR TITLE
Demonstrating sphinx autodoc capabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 sphinx==3.5.2
+pydata-sphinx-theme

--- a/source/api_reference/index.rst
+++ b/source/api_reference/index.rst
@@ -1,0 +1,23 @@
+.. _api_reference:
+
+API Reference
+=============
+
+Smartnoise-Core
+-------------------
+
+    .. toctree::
+        :maxdepth: 1
+
+        opendp.smartnoise.core.api
+        opendp.smartnoise.core.base
+        opendp.smartnoise.core.components
+        opendp.smartnoise.core.value
+
+Smartnoise-SDK
+-------------------
+
+    .. toctree::
+        :maxdepth: 1
+
+        opendp.smartnoise.sql

--- a/source/api_reference/opendp.smartnoise.core.api.rst
+++ b/source/api_reference/opendp.smartnoise.core.api.rst
@@ -1,0 +1,7 @@
+opendp\.smartnoise\.core\.api package
+=======================================
+
+.. automodule:: opendp.smartnoise.core.api
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/source/api_reference/opendp.smartnoise.core.base.rst
+++ b/source/api_reference/opendp.smartnoise.core.base.rst
@@ -1,0 +1,7 @@
+opendp\.smartnoise\.core\.base package
+=========================================
+
+.. automodule:: opendp.smartnoise.core.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/source/api_reference/opendp.smartnoise.core.components.rst
+++ b/source/api_reference/opendp.smartnoise.core.components.rst
@@ -1,0 +1,7 @@
+opendp\.smartnoise\.core\.components package
+===============================================
+
+.. automodule:: opendp.smartnoise.core.components
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/source/api_reference/opendp.smartnoise.core.value.rst
+++ b/source/api_reference/opendp.smartnoise.core.value.rst
@@ -1,0 +1,7 @@
+opendp\.smartnoise\.core\.value package
+=========================================
+
+.. automodule:: opendp.smartnoise.core.value
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/source/api_reference/opendp.smartnoise.sql.rst
+++ b/source/api_reference/opendp.smartnoise.sql.rst
@@ -1,0 +1,7 @@
+opendp\.smartnoise\.sql package
+=================================================
+
+.. automodule:: opendp.smartnoise.sql
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/source/conf.py
+++ b/source/conf.py
@@ -5,8 +5,21 @@ import os
 from datetime import datetime
 sys.path.insert(0, os.path.abspath('../../'))
 
+rootdir = os.path.join(os.getenv("SPHINX_MULTIVERSION_SOURCEDIR", default=os.getcwd()), "..")
+sys.path.insert(0, rootdir)
+print("*****************************************")
+[print(p) for p in sys.path]
+print("*****************************************")
+
+import opendp.smartnoise
+import opendp.smartnoise.synthesizers
+print(opendp.smartnoise.__spec__)
+print("*****************************************")
+
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
@@ -25,6 +38,7 @@ master_doc = 'index'
 # General information about the project.
 project = u'OpenDP'
 copyright = u'%d' % datetime.now().year
+# release = opendp.smartnoise.__version__
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -59,15 +73,20 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_theme_options = {
-    'logo': 'images/opendp-logo.png',
-    'description': 'Developing Open Source Tools for Differential Privacy',
+    'logo_link': 'images/opendp-logo.png',
+    "github_url": "https://github.com/opendp"
 }
+
+html_theme = 'pydata_sphinx_theme'
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
 
 # This is the file name suffix for HTML files (e.g. ".xhtml").
 #html_file_suffix = None
 htmlhelp_basename = 'OpenDPdoc'
 
-#html_logo = "_static/images/opendp-logo.png"
+html_logo = "_static/images/opendp-logo.png"
 
 rst_prolog = """
 .. |toctitle| replace:: Contents:

--- a/source/index.rst
+++ b/source/index.rst
@@ -13,6 +13,7 @@ OpenDP documentation is organized into the guides below. In addition to browsing
   quickstart/index
   user/index
   contrib/index
+  api_reference/index
 
 This is version |version| of the guides.
 


### PR DESCRIPTION
This is just an initial PR to demonstrate a potential api reference format across open-dp repositories.
**Please view the example live here: https://lurosenb.github.io**
**And the api reference stub here: https://lurosenb.github.io/api_reference/index.html**

This PR is small on purpose, and simply
- demonstrates potential spec for adding api reference to the existing sphinx docs. 
- migrates over to pydata theme as it is a little more modern/has parity with similar OSS projects.

Happy to make any necessary modifications and expand on the api reference here!
Need to go through smartnoise-sdk and move all the existing documentation over to sphinx format. (Smartnoise-core is already mostly there...)