### PR TITLE
`make html` for devs, `make versions` to deploy #22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           python -m venv venv
           source venv/bin/activate
           pip install -r requirements.txt
-          make html
+          make versions
           cp -r build /tmp
           git fetch
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
-SPHINXBUILD   = sphinx-multiversion
+SPHINXBUILD   = sphinx-build
+SPHINXMULTI   = sphinx-multiversion
 PAPER         =
 BUILDDIR      = build
 
@@ -22,8 +23,13 @@ clean:
 	rm -rf $(BUILDDIR)/*
 
 html:
+	$(SPHINXBUILD) $(SPHINXOPTS) -D 'html_sidebars.**'=search-field.html,sidebar-nav-bs.html source $(BUILDDIR)/html
+	@echo
+	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
+
+versions:
 	# "/en" is the default, but someday we might have translations
-	$(SPHINXBUILD) source $(BUILDDIR)/html/en
+	$(SPHINXMULTI) source $(BUILDDIR)/html/en
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	cp redirect.html $(BUILDDIR)/html/index.html

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ For users of SmartNoise, please visit these repositories:
  - The accompanying [SmartNoise SDK repository](https://github.com/opendp/smartnoise-sdk) and 
  - For examples: [SmartNoise Samples repository](https://github.com/opendp/smartnoise-samples) 
 
-## Dev Notes
+## Building the Docs
 
 ```
 python3 -m venv venv
@@ -20,4 +20,10 @@ make html
 open build/html/index.html
 ```
 
-Docs are currently deployed to http://docs.opendp.org
+## Deployment
+
+Docs are deployed to http://docs.opendp.org using GitHub Actions.
+
+Note that `make html` is replaced with `make versions` to build multiple versions (branches, tags) using the [sphinx-multiversion][] extension.
+
+[sphinx-multiversion]: https://holzhaus.github.io/sphinx-multiversion/

--- a/source/conf.py
+++ b/source/conf.py
@@ -79,9 +79,9 @@ html_theme_options = {
 html_theme = 'pydata_sphinx_theme'
 
 # See https://pydata-sphinx-theme.readthedocs.io/en/v0.6.3/user_guide/configuring.html#configure-the-sidebar
+# Note: Overridden in the Makefile for local builds. Be sure to update both places.
 html_sidebars = {
    '**': ['search-field.html', 'sidebar-nav-bs.html', 'versioning.html'],
-#   '**': ['search-field.html', 'sidebar-nav-bs.html',], # 'versioning.html'],
 }
 
 # Whitelist pattern for branches (set to None to ignore all branches)


### PR DESCRIPTION
Closes #22 

We want `make html` to work fine for devs who are editing the docs and
want to preview changes. Devs or doc writers or whatever.

When we build the docs to deploy to production, we want all the versions
of the docs to be built. These are only built from tags or the commits
in branches. That's how the sphinx-multiversion extension works. To call
this purpose `make versions` has been added.