### PR TITLE
treat warnings as errors #36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ html:
 
 versions:
 	# "/en" is the default, but someday we might have translations
-	$(SPHINXMULTI) source $(BUILDDIR)/html/en
+	$(SPHINXMULTI) $(SPHINXOPTS) source $(BUILDDIR)/html/en
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 	cp redirect.html $(BUILDDIR)/html/index.html


### PR DESCRIPTION
Closed #36 

$(SPHINXOPTS) contains -W ("turn warnings into errors") and is used for local builds already. It looks like this:

```
SPHINXOPTS = -W
```