### PR TITLE
add links to GitHub Discussions #27

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ Docs are deployed to http://docs.opendp.org using GitHub Actions.
 Note that `make html` is replaced with `make versions` to build multiple versions (branches, tags) using the [sphinx-multiversion][] extension.
 
 [sphinx-multiversion]: https://holzhaus.github.io/sphinx-multiversion/
+
+## Join the Discussion
+
+You are very welcome to join us on [GitHub Discussions][]!
+
+[GitHub Discussions]: https://github.com/opendp/opendp/discussions

--- a/source/conf.py
+++ b/source/conf.py
@@ -73,6 +73,19 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_theme_options = {
+    "external_links": [
+        {
+            "name": "GitHub Discussions",
+            "url": "https://github.com/opendp/opendp/discussions"
+        },
+    ],
+    "icon_links": [
+        {
+            "name": "GitHub Discussions",
+            "url": "https://github.com/opendp/opendp/discussions",
+            "icon": "far fa-comments",
+        },
+    ],
     "github_url": "https://github.com/opendp"
 }
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -73,12 +73,6 @@ html_last_updated_fmt = '%b %d, %Y'
 
 # Custom sidebar templates, maps document names to template names.
 html_theme_options = {
-    "external_links": [
-        {
-            "name": "GitHub Discussions",
-            "url": "https://github.com/opendp/opendp/discussions"
-        },
-    ],
     "icon_links": [
         {
             "name": "GitHub Discussions",

--- a/source/contact/index.rst
+++ b/source/contact/index.rst
@@ -1,0 +1,8 @@
+Contact
+=======
+
+A great way to get in contact with the OpenDP community is `GitHub Discussions`_.
+
+.. _GitHub Discussions: https://github.com/opendp/opendp/discussions
+
+For private or security-related matters, please email info@opendp.org.

--- a/source/contrib/intro.rst
+++ b/source/contrib/intro.rst
@@ -28,7 +28,9 @@ Other projects in the :doc:`/user/opendp-commons` have their own issue trackers.
 Getting Help
 ------------
 
-To discuss your contribution with OpenDP developers, open an issue at https://github.com/opendp/opendp/issues
+To discuss your contribution with OpenDP developers, please start a thread on `GitHub Discussions`_.
+
+.. _GitHub Discussions: https://github.com/opendp/opendp/discussions
 
 Other OpenDP Projects
 ---------------------

--- a/source/index.rst
+++ b/source/index.rst
@@ -14,6 +14,7 @@ OpenDP documentation is organized into the guides below. In addition to browsing
   user/index
   contrib/index
   smartnoise/index
+  contact/index
 
 This is version |version| of the guides.
 

--- a/source/smartnoise/overview.rst
+++ b/source/smartnoise/overview.rst
@@ -107,3 +107,10 @@ To best way to get started with SmartNoise is by reviewing and trying examples f
 .. _SQL Data Access: https://github.com/opendp/smartnoise-samples/tree/master/data
 .. _Microsoft SmartNoise Differential Privacy Machine Learning Case Studies: https://azure.microsoft.com/en-us/resources/microsoft-smartnoisedifferential-privacy-machine-learning-case-studies/
 .. _SmartNoise Whitepaper Demo Notebooks: https://github.com/opendp/smartnoise-samples/tree/master/whitepaper-demos
+
+Getting Help
+------------
+
+If you have questions or feedback regarding SmartNoise, you are welcome to post to the `SmartNoise section`_ of GitHub Discussions.
+
+.. _Smartnoise section: https://github.com/opendp/opendp/discussions/categories/smartnoise

--- a/source/user/faq.rst
+++ b/source/user/faq.rst
@@ -10,3 +10,10 @@ Where Can I Find Releases of OpenDP?
 The `releases`_ page for OpenDP will be updated each time a version of OpenDP has been released.
 
 .. _releases: https://github.com/opendp/opendp/releases
+
+Where Can I Discuss OpenDP?
+---------------------------
+
+A good place to talk about OpenDP is `GitHub Discussions`_.
+
+.. _GitHub Discussions: https://github.com/opendp/opendp/discussions

--- a/source/user/intro.rst
+++ b/source/user/intro.rst
@@ -31,3 +31,10 @@ This guide is intended primarily for developers or data scientists who want to m
 Data scientists and others who are more interested in a graphical user interface should review the offerings in the :doc:`opendp-commons`.
 
 Potential contributors to OpenDP should read the :doc:`/contrib/index`.
+
+Getting Help
+------------
+
+If you have questions or feedback regarding OpenDP, please feel free to post on `GitHub Discussions`_.
+
+.. _GitHub Discussions: https://github.com/opendp/opendp/discussions


### PR DESCRIPTION
Part of #27 

Since I added an icon in the header, here's a screenshot:

<img width="1083" alt="Screen Shot 2021-06-11 at 11 47 36 AM" src="https://user-images.githubusercontent.com/21006/121713821-3f96d500-caab-11eb-8f4c-46412fea5101.png">

Not that I also added a text link to the header. If this is too much we can remove one of them.

I also links to GitHub Discussions on various pages. I'm tempted to add a dedicated page called "Getting Help" (or something) under the User Guide (or Quickstart?) so that it shows up in the main table of contents, which currently looks like this:

<img width="438" alt="Screen Shot 2021-06-11 at 11 52 29 AM" src="https://user-images.githubusercontent.com/21006/121714259-aae0a700-caab-11eb-8c24-449c59c595eb.png">
