### PR TITLE
Added back synthesizers from PR #25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,6 @@ on:
   push:
     branches:
       - latest
-  pull_request:
-    branches:
-      - latest
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,11 +31,10 @@ jobs:
           python --version
           python -m venv venv
           source venv/bin/activate
-          pip --version   # version check
+          echo "Upgrade pip and install requirements."
           python -m pip install --upgrade pip
-          pip --version   # version check
-          pip install --upgrade setuptools
-          pip install --use-feature=2020-resolver -r requirements.txt
+          pip install -r requirements.txt
+          echo "Create docs."
           make versions
           cp -r build /tmp
           git fetch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Push docs to gh-pages branch
         run: |
           echo "Push docs to gh-pages branch"
-          #git commit --allow-empty-message --message "$(git log $(git rev-parse origin/latest) --oneline --format=%B -n1 | head -n1)"
-          #git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
-          #git push --force origin gh-pages
+          git commit --allow-empty-message --message "$(git log $(git rev-parse origin/latest) --oneline --format=%B -n1 | head -n1)"
+          git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
+          git push --force origin gh-pages
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,9 @@ on:
   push:
     branches:
       - latest
-      #- 17-sn-updates
-
+  pull_request:
+    branches:
+      - latest
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -30,7 +31,8 @@ jobs:
           python --version
           python -m venv venv
           source venv/bin/activate
-          pip install -r requirements.txt
+          pip install --upgrade setuptools
+          pip install --use-feature=2020-resolver -r requirements.txt
           make versions
           cp -r build /tmp
           git fetch
@@ -45,7 +47,7 @@ jobs:
       - name: Push docs to gh-pages branch
         run: |
           echo "Push docs to gh-pages branch"
-          git commit --allow-empty-message --message "$(git log $(git rev-parse origin/latest) --oneline --format=%B -n1 | head -n1)"
-          git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
-          git push --force origin gh-pages
+          #git commit --allow-empty-message --message "$(git log $(git rev-parse origin/latest) --oneline --format=%B -n1 | head -n1)"
+          #git remote set-url origin "https://$GITHUB_ACTOR:${{ secrets.GITHUB_TOKEN }}@github.com/$GITHUB_REPOSITORY"
+          #git push --force origin gh-pages
         continue-on-error: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,9 @@ jobs:
           python --version
           python -m venv venv
           source venv/bin/activate
+          pip --version   # version check
+          python -m pip install --upgrade pip
+          pip --version   # version check
           pip install --upgrade setuptools
           pip install --use-feature=2020-resolver -r requirements.txt
           make versions

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ For users of SmartNoise, please visit: [docs.opendp.org/en/latest/smartnoise](ht
 ```
 python3 -m venv venv
 source venv/bin/activate
+python -m pip install --upgrade pip
 pip install -r requirements.txt
 make html
 open build/html/index.html

--- a/README.md
+++ b/README.md
@@ -9,8 +9,14 @@ For users of SmartNoise, please visit: [docs.opendp.org/en/latest/smartnoise](ht
 
 ## Building the Docs
 
+The steps below assume the use of [Homebrew] on a Mac.
+
+[Homebrew]: https://brew.sh
+
+Note that Python 3.8 is required. Python 3.9 is known not to work with the synthesizers packages.
+
 ```
-python3 -m venv venv
+/usr/local/opt/python\@3.8/bin/python3 -m venv venv
 source venv/bin/activate
 python -m pip install --upgrade pip
 pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ sphinx-multiversion
 pydata-sphinx-theme
 opendp-smartnoise-core
 opendp-smartnoise
+opacus
+torch
+ctgan==0.2.2.dev1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ sphinx-multiversion
 pydata-sphinx-theme
 opendp-smartnoise-core
 opendp-smartnoise
-opacus
+opacus==0.9.0
 torch
-ctgan==0.2.2.dev0
+ctgan==0.2.2.dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ opendp-smartnoise-core
 opendp-smartnoise
 opacus
 torch
-ctgan==0.2.2.dev1
+ctgan==0.2.2.dev0

--- a/source/smartnoise/api-reference/index.rst
+++ b/source/smartnoise/api-reference/index.rst
@@ -20,3 +20,5 @@ SmartNoise-SDK
 
         opendp.smartnoise.sql
         opendp.smartnoise.metadata
+        opendp.smartnoise.synthesizers
+        opendp.smartnoise.synthesizers.pytorch.nn

--- a/source/smartnoise/api-reference/opendp.smartnoise.synthesizers.pytorch.nn.rst
+++ b/source/smartnoise/api-reference/opendp.smartnoise.synthesizers.pytorch.nn.rst
@@ -1,0 +1,26 @@
+opendp\.smartnoise\.synthesizers\.pytorch\.nn package
+=====================================================
+
+.. autoclass:: opendp.smartnoise.synthesizers.pytorch.nn.PATEGAN
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: opendp.smartnoise.synthesizers.pytorch.nn.DPGAN
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: opendp.smartnoise.synthesizers.pytorch.nn.PATECTGAN
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+    .. automethod:: __init__
+
+.. autoclass:: opendp.smartnoise.synthesizers.pytorch.nn.DPCTGAN
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+    .. automethod:: __init__

--- a/source/smartnoise/api-reference/opendp.smartnoise.synthesizers.rst
+++ b/source/smartnoise/api-reference/opendp.smartnoise.synthesizers.rst
@@ -1,0 +1,12 @@
+opendp\.smartnoise\.synthesizers package
+=================================================
+
+.. autoclass:: opendp.smartnoise.synthesizers.QUAILSynthesizer
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+.. autoclass:: opendp.smartnoise.synthesizers.MWEMSynthesizer
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
Now that the newest smartnoise release (0.1.4.1) fixes the issue with MWEM docstring (thanks for finding @pdurbin ), we could add back the synthesizers docs that @joshua-oss had added in #25 .

**Note**: If we add this back, we will need to add 3 dependencies to our reqs (torch, opacus, ctgan), as they are not default reqs in smartnoise by design.